### PR TITLE
Add "Plugin Stays Open" option

### DIFF
--- a/variant-switcher/CHANGELOG.md
+++ b/variant-switcher/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v7 (May 3, 2023)
+
+### Added
+
+-   Support for an advanced option "Plugin Stays Open". ([#46](https://github.com/etn-ccis/blui-figma-plugins/issues/46))
+
 ## v6 (Sept 26, 2022)
 
 ### Added

--- a/variant-switcher/CHANGELOG.md
+++ b/variant-switcher/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v7 (May 3, 2023)
+## v7 (May 5, 2023)
 
 ### Added
 

--- a/variant-switcher/README.md
+++ b/variant-switcher/README.md
@@ -18,6 +18,7 @@ The Variant Switcher plugin has several user controls:
 | Deep Switch          | When unchecked, the plugin will not switch children after switching their parent instances. ([Diagram explanation](./_assets_/deep-switch-diagram.png))                            | (yes)     |
 | Switch Full Document | When checked, the plugin will traverse through the entire document. When unchecked, the plugin will only switch the current selection, or the current page if nothing is selected. | (yes)     |
 | Exact Match          | Whether to check for the exact property name and variant name or do a fuzzy search instead.                                                                                        | (yes)     |
+| Plugin Stays Open    | Whether the plugin will stay open after clicking "Switch Variants"                                                                                                                 | (no)      |
 | Main Component Name  | Change only instances with the specified main component name                                                                                                                       | no        |
 
 ## Example

--- a/variant-switcher/src/code.ts
+++ b/variant-switcher/src/code.ts
@@ -8,8 +8,8 @@ import { KEYS } from './shared';
 import { fuzzyMatch } from './utils';
 
 const DELIMITER = ',';
-const EXPANDED_HEIGHT = 437;
-const COLLAPSED_HEIGHT = 234;
+const EXPANDED_HEIGHT = 460;
+const COLLAPSED_HEIGHT = 224;
 const DEFAULT_WIDTH = 300;
 
 figma.showUI(__html__, { themeColors: true, visible: false, width: DEFAULT_WIDTH, height: COLLAPSED_HEIGHT });
@@ -31,6 +31,9 @@ figma.clientStorage.getAsync(KEYS.FULL_DOCUMENT).then((val) => {
 });
 figma.clientStorage.getAsync(KEYS.EXACT_MATCH).then((val) => {
     if (val) figma.ui.postMessage({ param: KEYS.EXACT_MATCH, val });
+});
+figma.clientStorage.getAsync(KEYS.PLUGIN_STAY_OPEN).then((val) => {
+    if (val) figma.ui.postMessage({ param: KEYS.PLUGIN_STAY_OPEN, val });
 });
 figma.clientStorage.getAsync(KEYS.MAIN_COMPONENT_NAME).then((val) => {
     if (val) figma.ui.postMessage({ param: KEYS.MAIN_COMPONENT_NAME, val });
@@ -174,6 +177,7 @@ figma.ui.onmessage = (msg) => {
         figma.clientStorage.setAsync(KEYS.DEEP_SWITCH, msg.deepSwitch);
         figma.clientStorage.setAsync(KEYS.FULL_DOCUMENT, msg.fullDocument);
         figma.clientStorage.setAsync(KEYS.EXACT_MATCH, msg.exactMatch);
+        figma.clientStorage.setAsync(KEYS.PLUGIN_STAY_OPEN, msg.pluginStayOpen);
         figma.clientStorage.setAsync(KEYS.MAIN_COMPONENT_NAME, msg.mainComponentName);
         figma.clientStorage.setAsync(KEYS.SHOW_ADVANCED_OPTIONS, msg.showAdvancedOptions);
 
@@ -238,7 +242,10 @@ figma.ui.onmessage = (msg) => {
         } else {
             figma.notify(`Changed ${switchCount} instances' "${notifyPropertyName}" to "${notifyToVariant}".`);
         }
-        figma.closePlugin();
+
+        if (msg.pluginStayOpen === 'false') {
+            figma.closePlugin();
+        }
     } else if (msg.action === 'resize') {
         if (msg.showAdvancedOptions) {
             figma.ui.resize(DEFAULT_WIDTH, EXPANDED_HEIGHT);

--- a/variant-switcher/src/code.ts
+++ b/variant-switcher/src/code.ts
@@ -246,6 +246,8 @@ figma.ui.onmessage = (msg) => {
         if (msg.pluginStayOpen === 'false') {
             figma.closePlugin();
         }
+
+        switchCount = 0;
     } else if (msg.action === 'resize') {
         if (msg.showAdvancedOptions) {
             figma.ui.resize(DEFAULT_WIDTH, EXPANDED_HEIGHT);

--- a/variant-switcher/src/shared.ts
+++ b/variant-switcher/src/shared.ts
@@ -11,6 +11,7 @@ export const KEYS = {
     DEEP_SWITCH: 'deep-switch',
     FULL_DOCUMENT: 'full-document',
     EXACT_MATCH: 'exact-match',
+    PLUGIN_STAY_OPEN: 'plugin-stay-open',
     MAIN_COMPONENT_NAME: 'main-component-name',
     SHOW_ADVANCED_OPTIONS: 'show-advanced-options',
 };

--- a/variant-switcher/src/ui.tsx
+++ b/variant-switcher/src/ui.tsx
@@ -27,6 +27,7 @@ const App: React.FC = () => {
     const [deepSwitch, setDeepSwitch] = React.useState<'true' | 'false'>('false');
     const [fullDocument, setFullDocument] = React.useState<'true' | 'false'>('false');
     const [exactMatch, setExactMatch] = React.useState<'true' | 'false'>('true');
+    const [pluginStayOpen, setPluginStayOpen] = React.useState<'true' | 'false'>('false');
     const [mainComponentName, setMainComponentName] = React.useState('');
 
     const [showAdvancedOptions, setShowAdvancedOptions] = React.useState(false);
@@ -70,6 +71,12 @@ const App: React.FC = () => {
                 clearInterval(timerExactMatch);
             }
         }, 50);
+        const timerPluginStayOpen = setInterval(() => {
+            if (LOCAL_STORAGE_DATA[KEYS.PLUGIN_STAY_OPEN]) {
+                setExactMatch(LOCAL_STORAGE_DATA[KEYS.PLUGIN_STAY_OPEN]);
+                clearInterval(timerPluginStayOpen);
+            }
+        }, 50);
         const timerMainComponentName = setInterval(() => {
             if (LOCAL_STORAGE_DATA[KEYS.MAIN_COMPONENT_NAME]) {
                 setMainComponentName(LOCAL_STORAGE_DATA[KEYS.MAIN_COMPONENT_NAME]);
@@ -89,6 +96,7 @@ const App: React.FC = () => {
             clearInterval(timerDeepSwitch);
             clearInterval(timerFullDocument);
             clearInterval(timerExactMatch);
+            clearInterval(timerPluginStayOpen);
             clearInterval(timerMainComponentName);
             clearInterval(timerShowAdvancedOptions);
         };
@@ -107,6 +115,7 @@ const App: React.FC = () => {
                         deepSwitch,
                         fullDocument,
                         exactMatch,
+                        pluginStayOpen,
                         mainComponentName,
                         showAdvancedOptions,
                     },
@@ -121,6 +130,7 @@ const App: React.FC = () => {
         deepSwitch,
         fullDocument,
         exactMatch,
+        pluginStayOpen,
         mainComponentName,
         showAdvancedOptions,
     ]);
@@ -263,6 +273,30 @@ const App: React.FC = () => {
                         >
                             <label htmlFor={'exactMatch'} title={'Whether to do an exact match or a fuzzy search'}>
                                 Exact match
+                            </label>
+                        </div>
+                    </div>
+                    <div className={'checkbox-row'} style={{ alignItems: 'center' }}>
+                        <input
+                            type={'checkbox'}
+                            onChange={(e) => {
+                                setExactMatch(e.target.value === 'true' ? 'false' : 'true');
+                            }}
+                            name={'pluginStayOpen'}
+                            value={pluginStayOpen}
+                            checked={pluginStayOpen === 'true'}
+                        />
+                        <div
+                            onClick={(e) => {
+                                setPluginStayOpen(pluginStayOpen === 'true' ? 'false' : 'true');
+                            }}
+                            style={{ height: 'unset' }}
+                        >
+                            <label
+                                htmlFor={'pluginStayOpen'}
+                                title={'Whether the plugin will stay open after clicking "Switch Variants"'}
+                            >
+                                Plugin Stays Open
                             </label>
                         </div>
                     </div>


### PR DESCRIPTION
<!-- If this pull request fixes an Issue, link it below. If not, you can remove the line below -->

Fixes #46 

## Changes proposed in this Pull Request:

- Added an option to make the plugin stays open after a user clicks "Switch Variant" (default false)

## Screenshots / Screen Recording (if applicable)

https://user-images.githubusercontent.com/8997218/235758109-f0410408-244b-4ab6-820c-efe260cf15ce.mov


## To Test:

- Follow the build instruction in `variant-switcher/README.md`, under the "Running Plugin Locally (For Developers)" section
